### PR TITLE
feat(repo): Configure local gradle build cache for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,13 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
+      - name: Restore Gradle Build Cache
+        uses: actions/cache/restore@v3
+        with:
+          path: ./build-cache
+          restore-keys: |
+            gradle-build-cache
+
       - name: Build
         run: ./gradlew build -x bootJar -x check
 
@@ -34,3 +41,10 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: ./gradlew bootBuildImage --publishImage
+
+      - name: Save Gradle Build Cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: ./build-cache
+          key: gradle-build-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: ./build-cache
-          restore-keys: |
-            gradle-build-cache
+          key: gradle-build-cache
 
       - name: Build
         run: ./gradlew build -x bootJar -x check

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+build-cache/
 
 ### IntelliJ IDEA ###
 .idea

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.caching=true

--- a/services/vets-service/build.gradle.kts
+++ b/services/vets-service/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.springframework.boot.gradle.tasks.bundling.BootBuildImage
+
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
@@ -13,6 +15,6 @@ tasks.test {
     jvmArgs(listOf("--enable-preview"))
 }
 
-tasks.bootBuildImage {
+tasks.withType<BootBuildImage> {
     environment.put("BPE_APPEND_JAVA_TOOL_OPTIONS", "--enable-preview")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,13 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
 }
 
+buildCache {
+    local {
+        directory = File(rootDir, "build-cache")
+        removeUnusedEntriesAfterDays = 30
+    }
+}
+
 rootProject.name = "pet-clinic-monorepo"
 include("services:customers-service")
 include("services:vets-service")


### PR DESCRIPTION
Configre local gradle build cache. Used Github Actions caching to reuse those files across builds

### Initial run
<img width="1280" alt="image" src="https://github.com/Antrakos/pet-clinic-monorepo/assets/13787714/ea051709-4bd6-4de6-8179-95ec686a8f71">

### Following run
<img width="1280" alt="image" src="https://github.com/Antrakos/pet-clinic-monorepo/assets/13787714/cfbcd363-9ea3-49e2-83b6-18865f4bf841">
